### PR TITLE
Ensure randomNum includes upper bound

### DIFF
--- a/src/algorithms/lib.js
+++ b/src/algorithms/lib.js
@@ -1,4 +1,4 @@
-// Get a random number between minimum and maximum number
+// Get a random integer between minimum and maximum numbers (inclusive)
 export function randomNum(min, max) {
-  return Math.floor(Math.random() * (max - min) + min);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
 }

--- a/src/algorithms/lib.test.js
+++ b/src/algorithms/lib.test.js
@@ -1,0 +1,16 @@
+import { randomNum } from './lib';
+
+test('randomNum returns values within range and includes max', () => {
+  const min = 1;
+  const max = 2;
+  let sawMax = false;
+  for (let i = 0; i < 1000; i++) {
+    const value = randomNum(min, max);
+    expect(value).toBeGreaterThanOrEqual(min);
+    expect(value).toBeLessThanOrEqual(max);
+    if (value === max) {
+      sawMax = true;
+    }
+  }
+  expect(sawMax).toBe(true);
+});


### PR DESCRIPTION
## Summary
- fix random number generator so max value can be returned
- add unit test for randomNum covering inclusive bounds

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898396d8d0c8325880a6cb6432e1bc3