### PR TITLE
fix: pin postcss-safe-parser for Node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,11 @@
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "prettier": "2.2.1"
+  },
+  "overrides": {
+    "postcss-safe-parser": "4.0.2"
+  },
+  "resolutions": {
+    "postcss-safe-parser": "4.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- pin postcss-safe-parser to 4.0.2 (npm override + yarn resolution)

## Why
Fixes startup/runtime breakage on current Node environments caused by postcss-safe-parser pulling an incompatible postcss subpath.

## Validation
- npm install succeeds
- app starts successfully after dependency pin

## Scope
- This PR is only the Node/PostCSS compatibility fix.
- React upgrade is separated in PR #4.
